### PR TITLE
サイドバーの高さをコンテンツに合せるように修正しました。

### DIFF
--- a/rubima.css
+++ b/rubima.css
@@ -14,8 +14,7 @@ Copyright 2004 (C) by Yamamoto Dan <dan@dgames.jp>
 
 
 body {
-	margin-top: 0px;
-	margin-left: 0.4em;
+	margin: 0;
 	color: #000;
 	background-color: #fff;
 }
@@ -116,6 +115,12 @@ div.comment {
 div.trackbacks {
 	font-size: small;
 	display: inline;
+}
+
+/* whole-contents */
+div.whole-contents {
+	position: relative;
+	overflow: hidden;
 }
 
 /* main */
@@ -350,10 +355,11 @@ div.sidebar {
 	top: 0em;
 	left: 0px;
 	width: 150px;
-	padding-top: 148px;
-	padding-bottom: 5em;
 	color: #fee;
 	word-break: break-all;
+	padding-top: 148px;
+	padding-bottom: 32768px;
+	margin-bottom: -32768px;
 }
 
 div.sidebar h4 {


### PR DESCRIPTION
Mac版Chrome、Firefox、Safari で確認しています。
body に当っていた `margin-left: 0.4em;` の意図が不明だったので消してしまっているのですが、もしも影響があるようであれば、このpullreq自体見直す必要があります。

![2013-09-03 0 04 44](https://f.cloud.github.com/assets/9955/1067992/16565834-13e1-11e3-9d7a-1c5163efeba2.png)
